### PR TITLE
fix(supabase): Issue #365 - Fix soft delete filtering and hard delete bug

### DIFF
--- a/services/supabase/core.ts
+++ b/services/supabase/core.ts
@@ -314,7 +314,7 @@ return this.executeWithRetry(async () => {
     return this.executeWithRetry(async () => {
       if (!this.client) throw new Error('Supabase client not initialized');
 
-      let query = this.client.from('robots').select('*');
+      let query = this.client.from('robots').select('*').is('deleted_at', null);
       if (userId) {
         query = query.eq('user_id', userId);
       }
@@ -360,6 +360,7 @@ return this.executeWithRetry(async () => {
         .from('robots')
         .select('*')
         .eq('id', id)
+        .is('deleted_at', null)
         .single();
 
       if (error) {
@@ -487,7 +488,7 @@ return this.executeWithRetry(async () => {
 
       const { error } = await this.client
         .from('robots')
-        .delete()
+        .update({ deleted_at: new Date().toISOString() })
         .eq('id', id);
 
       if (error) throw error;


### PR DESCRIPTION
## Summary

Fixes Issue #365 - CoreSupabaseService Missing Soft Delete Filter and Hard Delete Bug

## Bug Fixes

### Bug 1: Missing Soft Delete Filters
- getRobots() (line 317): Added `.is('deleted_at', null)` to exclude soft-deleted records
- getRobot() (line 362): Added `.is('deleted_at', null)` to exclude soft-deleted records

### Bug 2: Hard Delete Instead of Soft Delete
- deleteRobot() (line 491): Changed from `.delete()` to `.update({ deleted_at: new Date().toISOString() })`

## Impact

- Soft-deleted robots will no longer appear in query results
- Delete operations now properly implement soft delete pattern per migration 004
- Data can be recovered after deletion (deleted_at timestamp preserved)

## Testing

- TypeScript compilation: Passes (0 errors)
- Production build: Passes (14.41s)
- Test suite: 445/445 tests passing

## Files Changed

- services/supabase/core.ts (3 lines modified)

Fixes #365
